### PR TITLE
Add Angular 22 support and migrate to @andreasnicolaou/toastify 2.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,30 +15,53 @@ npm install @andreasnicolaou/ngx-toastify @andreasnicolaou/toastify
 
 > Make sure both ngx-toastify and its underlying core package are installed.
 
+### Compatibility
+
+| ngx-toastify | Angular | @andreasnicolaou/toastify |
+| ------------ | ------- | ------------------------- |
+| 2.x          | 19 – 22 | ^2.2.0                    |
+| 1.x          | 14 – 19 | ^1.1.0                    |
+
 ## 🚀 Quick Start
 
-1. Import `NgxToastifyModule` in your `AppModule`
+### Standalone applications (recommended)
+
+```typescript
+import { bootstrapApplication } from '@angular/platform-browser';
+import { provideNgxToastify } from '@andreasnicolaou/ngx-toastify';
+
+bootstrapApplication(AppComponent, {
+  providers: [
+    provideNgxToastify({
+      position: 'top-right',
+      options: { maxToasts: 3, customClasses: 'my-toast' },
+    }),
+  ],
+});
+```
+
+### NgModule applications
 
 ```typescript
 import { NgxToastifyModule } from '@andreasnicolaou/ngx-toastify';
 
 @NgModule({
   imports: [
-    NgxToastifyModule.forRoot('top-right', {
-      maxToasts: 3,
-      customClasses: 'my-toast',
+    NgxToastifyModule.forRoot({
+      position: 'top-right',
+      options: { maxToasts: 3, customClasses: 'my-toast' },
     }),
   ],
 })
 export class AppModule {}
 ```
 
-> `forRoot()` is optional. If omitted, it will use default values.
+> Configuration is optional. `NgxToastifyService` is `providedIn: 'root'`, so you can inject it without any setup and get the defaults (`top-right`, no overrides).
 
-2. Use the `NgxToastifyService` in your components
+### Showing a toast
 
 ```typescript
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { NgxToastifyService } from '@andreasnicolaou/ngx-toastify';
 
 @Component({
@@ -46,30 +69,44 @@ import { NgxToastifyService } from '@andreasnicolaou/ngx-toastify';
   template: `<button (click)="showToast()">Show Toast</button>`,
 })
 export class ExampleComponent {
-  constructor(private ngxToastifyService: NgxToastifyService) {}
+  private readonly toast = inject(NgxToastifyService);
 
-  showToast() {
-    this.ngxToastifyService.success({ title: 'Success!', message: 'This is a toast message.' });
+  showToast(): void {
+    this.toast.success({ title: 'Success!', message: 'This is a toast message.' });
   }
 }
 ```
 
+## 🔄 Updating a live toast
+
+Every toast method returns a `ToastifyHandle`, which lets you mutate the toast in place while it is still visible. If the toast is still queued (because `maxToasts` was exceeded), updates are buffered and replayed once it appears.
+
+```typescript
+const handle = this.toast.info({ title: 'Upload', message: 'Uploading…' });
+
+handle.update({ message: 'Processing…' });
+handle.update({ type: 'success', message: 'Done!', withProgressBar: true });
+```
+
 ## 🧩 Features
 
-- Simple toast API: success, error, info, warning, default
+- Simple toast API: `default`, `light`, `success`, `error`, `warning`, `info`
+- Standalone `provideNgxToastify()` and NgModule `forRoot()` entry points
+- In-place toast updates via the returned `ToastifyHandle`
 - Uses [`@andreasnicolaou/toastify`](https://www.npmjs.com/package/@andreasnicolaou/toastify) under the hood
-- Optional configuration using forRoot()
-- Type-safe toast options
+- Type-safe toast options, with core types re-exported
 - Custom CSS class support
 
 ## 🛠 API
 
 ### `NgxToastifyService` Methods
 
+All methods take the same arguments and return a `ToastifyHandle`.
+
 | Method    | Parameters                                                       | Description           |
 | --------- | ---------------------------------------------------------------- | --------------------- |
 | `default` | `{ title: string, message?: string }, options?: ToastifyOptions` | Shows a default toast |
-| `light`   | `{ title: string, message?: string }, options?: ToastifyOptions` | Shows a light toast |
+| `light`   | `{ title: string, message?: string }, options?: ToastifyOptions` | Shows a light toast   |
 | `success` | `{ title: string, message?: string }, options?: ToastifyOptions` | Shows a success toast |
 | `error`   | `{ title: string, message?: string }, options?: ToastifyOptions` | Shows an error toast  |
 | `warning` | `{ title: string, message?: string }, options?: ToastifyOptions` | Shows a warning toast |
@@ -77,7 +114,30 @@ export class ExampleComponent {
 
 - **`title`**: Required — the headline of the toast
 - **`message`**: Optional — the body text (defaults to `''`)
-- **`options`**: Optional — configuration object from the core [`@andreasnicolaou/toastify`](https://www.npmjs.com/package/@andreasnicolaou/toastify) package
+- **`options`**: Optional — per-toast overrides, merged over the configured defaults
+
+### Configuration
+
+`provideNgxToastify(config?)` and `NgxToastifyModule.forRoot(config?)` both accept:
+
+| Field      | Type                 | Description                                       |
+| ---------- | -------------------- | ------------------------------------------------- |
+| `position` | `ToastifyPosition`   | Container position. Defaults to `'top-right'`     |
+| `options`  | `NgxToastifyOptions` | Default `ToastifyOptions` plus container settings |
+
+`NgxToastifyOptions` extends `ToastifyOptions` with the container-level settings that can only be set once, when the manager is created:
+
+| Option          | Type      | Description                                |
+| --------------- | --------- | ------------------------------------------ |
+| `maxToasts`     | `number`  | Max toasts visible at once (default `5`)   |
+| `customClasses` | `string`  | Extra CSS classes applied to the container |
+| `newestOnTop`   | `boolean` | Whether new toasts stack on top            |
+
+Per-toast `ToastifyOptions` (`duration`, `isHtml`, `withProgressBar`, `progressBarDuration`, `closeButton`, `direction`, `showIcons`, `animationType`, `tapToDismiss`, `progressBarDirection`) are documented in the [core package](https://www.npmjs.com/package/@andreasnicolaou/toastify).
+
+### Exports
+
+`NgxToastifyService`, `NgxToastifyModule`, `provideNgxToastify`, `TOASTIFY_POSITION`, `TOASTIFY_OPTIONS`, `DEFAULT_TOASTIFY_POSITION`, and the types `NgxToastifyConfig`, `NgxToastifyOptions`. The core types `ToastifyHandle`, `ToastifyOptions`, `ToastifyPosition`, `ToastifyType`, `ToastifyAnimationType`, and `ToastifyUpdateOptions` are re-exported so you don't need to import from the core package directly.
 
 ## 🎨 Styles
 
@@ -89,6 +149,13 @@ To include the styles from @andreasnicolaou/toastify, add the CSS manually:
   "node_modules/@andreasnicolaou/toastify/dist/styles.css"
 ]
 ```
+
+## ⬆️ Migrating from 1.x
+
+- Requires `@andreasnicolaou/toastify` **^2.2.0** (was `^1.1.0`) and Angular **19+** (was 14+).
+- `NgxToastifyModule.forRoot()` takes a single config object: `forRoot({ position, options })`. Earlier README examples showed `forRoot('top-right', {...})`, which never matched the actual signature.
+- Toast methods now return `ToastifyHandle` instead of `void`. This is additive — existing call sites keep working.
+- `NgxToastifyService` is now `providedIn: 'root'`, so injecting it without importing the module no longer throws.
 
 ## 📦 Contribution
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@andreasnicolaou/ngx-toastify",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Angular wrapper for @andreasnicolaou/toastify — a lightweight toast notification manager.",
   "private": false,
   "publishConfig": {
@@ -20,9 +20,9 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "@andreasnicolaou/toastify": "^1.1.0",
-    "@angular/common": ">=14.0.0 <20.0.0",
-    "@angular/core": ">=14.0.0 <20.0.0"
+    "@andreasnicolaou/toastify": "^2.2.0",
+    "@angular/common": ">=19.0.0 <23.0.0",
+    "@angular/core": ">=19.0.0 <23.0.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/src/lib/ngx-toastify.module.ts
+++ b/src/lib/ngx-toastify.module.ts
@@ -1,41 +1,25 @@
 import { ModuleWithProviders, NgModule } from '@angular/core';
-import { NgxToastifyService } from './ngx-toastify.service';
-import { ToastifyPosition, ToastifyOptions } from '@andreasnicolaou/toastify';
-import { TOASTIFY_OPTIONS, TOASTIFY_POSITION } from './ngx-toastify.tokens';
+import { NgxToastifyConfig } from './ngx-toastify.providers';
+import { DEFAULT_TOASTIFY_POSITION, TOASTIFY_OPTIONS, TOASTIFY_POSITION } from './ngx-toastify.tokens';
 
-@NgModule({
-  providers: [
-    {
-      provide: TOASTIFY_POSITION,
-      useValue: 'top-right',
-    },
-    {
-      provide: TOASTIFY_OPTIONS,
-      useValue: undefined,
-    },
-    NgxToastifyService,
-  ],
-})
+/**
+ * NgModule entry point, kept for NgModule-based applications.
+ * Standalone applications should use `provideNgxToastify()` instead.
+ */
+@NgModule({})
 export class NgxToastifyModule {
-  static forRoot(config?: {
-    position?: ToastifyPosition;
-    options?: ToastifyOptions & {
-      maxToasts?: number;
-      customClasses?: string;
-    };
-  }): ModuleWithProviders<NgxToastifyModule> {
+  static forRoot(config?: NgxToastifyConfig): ModuleWithProviders<NgxToastifyModule> {
     return {
       ngModule: NgxToastifyModule,
       providers: [
         {
           provide: TOASTIFY_POSITION,
-          useValue: config?.position ?? 'top-right',
+          useValue: config?.position ?? DEFAULT_TOASTIFY_POSITION,
         },
         {
           provide: TOASTIFY_OPTIONS,
           useValue: config?.options,
         },
-        NgxToastifyService,
       ],
     };
   }

--- a/src/lib/ngx-toastify.providers.ts
+++ b/src/lib/ngx-toastify.providers.ts
@@ -1,0 +1,28 @@
+import { EnvironmentProviders, makeEnvironmentProviders } from '@angular/core';
+import { ToastifyPosition } from '@andreasnicolaou/toastify';
+import {
+  DEFAULT_TOASTIFY_POSITION,
+  NgxToastifyOptions,
+  TOASTIFY_OPTIONS,
+  TOASTIFY_POSITION,
+} from './ngx-toastify.tokens';
+
+export interface NgxToastifyConfig {
+  position?: ToastifyPosition;
+  options?: NgxToastifyOptions;
+}
+
+/**
+ * Configures NgxToastify for a standalone application.
+ *
+ * @example
+ * bootstrapApplication(AppComponent, {
+ *   providers: [provideNgxToastify({ position: 'bottom-right', options: { maxToasts: 3 } })],
+ * });
+ */
+export function provideNgxToastify(config?: NgxToastifyConfig): EnvironmentProviders {
+  return makeEnvironmentProviders([
+    { provide: TOASTIFY_POSITION, useValue: config?.position ?? DEFAULT_TOASTIFY_POSITION },
+    { provide: TOASTIFY_OPTIONS, useValue: config?.options },
+  ]);
+}

--- a/src/lib/ngx-toastify.service.ts
+++ b/src/lib/ngx-toastify.service.ts
@@ -1,45 +1,48 @@
-import { Inject, Injectable, Optional } from '@angular/core';
-import { ToastifyManager, ToastifyOptions, ToastifyPosition } from '@andreasnicolaou/toastify';
-import { TOASTIFY_OPTIONS, TOASTIFY_POSITION } from './ngx-toastify.tokens';
+import { Injectable, inject } from '@angular/core';
+import { ToastifyHandle, ToastifyManager, ToastifyOptions, ToastifyPosition } from '@andreasnicolaou/toastify';
+import {
+  DEFAULT_TOASTIFY_POSITION,
+  NgxToastifyOptions,
+  TOASTIFY_OPTIONS,
+  TOASTIFY_POSITION,
+} from './ngx-toastify.tokens';
 
-@Injectable()
+type ToastContent = { title: string; message?: string };
+
+@Injectable({ providedIn: 'root' })
 export class NgxToastifyService {
-  private readonly toastify!: ToastifyManager;
+  public readonly position: ToastifyPosition;
+  public readonly options?: NgxToastifyOptions;
 
-  constructor(
-    @Inject(TOASTIFY_POSITION) public position: ToastifyPosition = 'top-right',
-    @Optional()
-    @Inject(TOASTIFY_OPTIONS)
-    public options?: ToastifyOptions & {
-      maxToasts?: number;
-      customClasses?: string;
-    }
-  ) {
-    this.toastify =
-      typeof options !== 'undefined' ? new ToastifyManager(position, options) : new ToastifyManager(position);
+  private readonly toastify: ToastifyManager;
+
+  constructor() {
+    this.position = inject(TOASTIFY_POSITION, { optional: true }) ?? DEFAULT_TOASTIFY_POSITION;
+    this.options = inject(TOASTIFY_OPTIONS, { optional: true }) ?? undefined;
+    this.toastify = new ToastifyManager(this.position, this.options);
   }
 
-  public default({ title, message = '' }: { title: string; message: string }, options?: ToastifyOptions): void {
-    this.toastify.default(title, message, options);
+  public default({ title, message = '' }: ToastContent, options?: ToastifyOptions): ToastifyHandle {
+    return this.toastify.default(title, message, options);
   }
 
-  public light({ title, message = '' }: { title: string; message: string }, options?: ToastifyOptions): void {
-    this.toastify.light(title, message, options);
+  public light({ title, message = '' }: ToastContent, options?: ToastifyOptions): ToastifyHandle {
+    return this.toastify.light(title, message, options);
   }
 
-  public success({ title, message = '' }: { title: string; message?: string }, options?: ToastifyOptions): void {
-    this.toastify.success(title, message, options);
+  public success({ title, message = '' }: ToastContent, options?: ToastifyOptions): ToastifyHandle {
+    return this.toastify.success(title, message, options);
   }
 
-  public error({ title, message = '' }: { title: string; message?: string }, options?: ToastifyOptions): void {
-    this.toastify.error(title, message, options);
+  public error({ title, message = '' }: ToastContent, options?: ToastifyOptions): ToastifyHandle {
+    return this.toastify.error(title, message, options);
   }
 
-  public warning({ title, message = '' }: { title: string; message?: string }, options?: ToastifyOptions): void {
-    this.toastify.warning(title, message, options);
+  public warning({ title, message = '' }: ToastContent, options?: ToastifyOptions): ToastifyHandle {
+    return this.toastify.warning(title, message, options);
   }
 
-  public info({ title, message = '' }: { title: string; message?: string }, options?: ToastifyOptions): void {
-    this.toastify.info(title, message, options);
+  public info({ title, message = '' }: ToastContent, options?: ToastifyOptions): ToastifyHandle {
+    return this.toastify.info(title, message, options);
   }
 }

--- a/src/lib/ngx-toastify.tokens.ts
+++ b/src/lib/ngx-toastify.tokens.ts
@@ -1,5 +1,17 @@
 import { ToastifyOptions, ToastifyPosition } from '@andreasnicolaou/toastify';
 import { InjectionToken } from '@angular/core';
 
+/**
+ * Options accepted by `ToastifyManager`, i.e. the per-toast defaults plus the
+ * container-level settings that can only be set once when the manager is created.
+ */
+export type NgxToastifyOptions = ToastifyOptions & {
+  maxToasts?: number;
+  customClasses?: string;
+  newestOnTop?: boolean;
+};
+
 export const TOASTIFY_POSITION = new InjectionToken<ToastifyPosition>('TOASTIFY_POSITION');
-export const TOASTIFY_OPTIONS = new InjectionToken<ToastifyOptions>('TOASTIFY_OPTIONS');
+export const TOASTIFY_OPTIONS = new InjectionToken<NgxToastifyOptions>('TOASTIFY_OPTIONS');
+
+export const DEFAULT_TOASTIFY_POSITION: ToastifyPosition = 'top-right';

--- a/src/public-api.ts
+++ b/src/public-api.ts
@@ -3,3 +3,18 @@
  */
 export { NgxToastifyModule } from './lib/ngx-toastify.module';
 export { NgxToastifyService } from './lib/ngx-toastify.service';
+export { provideNgxToastify } from './lib/ngx-toastify.providers';
+export type { NgxToastifyConfig } from './lib/ngx-toastify.providers';
+export { DEFAULT_TOASTIFY_POSITION, TOASTIFY_OPTIONS, TOASTIFY_POSITION } from './lib/ngx-toastify.tokens';
+export type { NgxToastifyOptions } from './lib/ngx-toastify.tokens';
+
+// Re-exported from the core package so consumers can type their toast calls
+// without importing @andreasnicolaou/toastify directly.
+export type {
+  ToastifyAnimationType,
+  ToastifyHandle,
+  ToastifyOptions,
+  ToastifyPosition,
+  ToastifyType,
+  ToastifyUpdateOptions,
+} from '@andreasnicolaou/toastify';


### PR DESCRIPTION
BREAKING CHANGE: requires @andreasnicolaou/toastify ^2.2.0 and Angular 19-22.

- Bump peer dependencies to @andreasnicolaou/toastify ^2.2.0 and
  @angular/{core,common} >=19.0.0 <23.0.0
- Return ToastifyHandle from all toast methods so callers can update a
  live toast in place via handle.update()
- Add provideNgxToastify() for standalone applications
- Make NgxToastifyService providedIn: 'root' with optional token
  injection, so injecting it without forRoot() no longer throws
- Expose newestOnTop through the new NgxToastifyOptions type
- Export the injection tokens and re-export the core Toastify types
- Fix the documented forRoot() signature in the README, which showed
  forRoot('top-right', {...}) instead of forRoot({ position, options })
